### PR TITLE
Add checking Period when register starred places to import

### DIFF
--- a/src/Pinventory.Pins.Domain/Importing/Import.cs
+++ b/src/Pinventory.Pins.Domain/Importing/Import.cs
@@ -83,7 +83,7 @@ namespace Pinventory.Pins.Domain.Importing
                 return Result.Fail(Errors.Import.PlacesCannotBeEmpty());
             }
 
-            foreach (var place in places)
+            foreach (var place in places.Where(IsInPeriod))
             {
                 if (_starredPlaces.Add(place))
                 {
@@ -92,6 +92,8 @@ namespace Pinventory.Pins.Domain.Importing
             }
 
             return Result.Ok();
+
+            bool IsInPeriod(StarredPlace place) => place.AddedDate >= Period.Start && place.AddedDate <= Period.End;
         }
 
         public async Task<Result<(IEnumerable<StarredPlace> ToCreate, IEnumerable<StarredPlace> ToUpdate)>> ProcessPlacesAsync(

--- a/src/Pinventory.Pins.Domain/Period.cs
+++ b/src/Pinventory.Pins.Domain/Period.cs
@@ -3,7 +3,7 @@
 namespace Pinventory.Pins.Domain;
 
 // TODO: Maybe replace with NodaTime 
-public partial record Period
+public sealed record Period
 {
     private Period(DateTimeOffset start, DateTimeOffset end)
     {
@@ -20,6 +20,11 @@ public partial record Period
     {
         start ??= DateTimeOffset.UnixEpoch;
         end ??= DateTimeOffset.UtcNow;
+
+        if (start < DateTimeOffset.UnixEpoch)
+        {
+            start = DateTimeOffset.UnixEpoch;
+        }
 
         return start >= end
             ? Result.Fail<Period>(Errors.Period.PeriodStartMustBeBeforeEnd(start, end))

--- a/src/Pinventory.Web/Components/Pages/Import.razor
+++ b/src/Pinventory.Web/Components/Pages/Import.razor
@@ -332,8 +332,8 @@
             ResetCounters();
             importId = null;
             statusMessage = "Starting import...";
-            var id = await PinsClient.StartImport(new StartImportDto());
-            archiveJobId = id;
+            var request = new StartImportDto { Start = importJobs.Max(j => j.CompletedAt ?? DateTimeOffset.UnixEpoch) };
+            archiveJobId = await PinsClient.StartImport(request);
             isImportRunning = true;
             statusMessage = "Preparing data...";
             successMessage = "Import started.";

--- a/src/Pinventory.Web/Components/Pages/Import.razor
+++ b/src/Pinventory.Web/Components/Pages/Import.razor
@@ -332,7 +332,7 @@
             ResetCounters();
             importId = null;
             statusMessage = "Starting import...";
-            var request = new StartImportDto { Start = importJobs.Max(j => j.CompletedAt ?? DateTimeOffset.UnixEpoch) };
+            var request = new StartImportDto { Start = importJobs.Where(j => j.CompletedAt != null).Select(j => j.CompletedAt!.Value).DefaultIfEmpty(DateTimeOffset.UnixEpoch).Max() };
             archiveJobId = await PinsClient.StartImport(request);
             isImportRunning = true;
             statusMessage = "Preparing data...";

--- a/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportCommandHandlerTests.cs
+++ b/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportCommandHandlerTests.cs
@@ -161,7 +161,7 @@ public class ImportCommandHandlerTests
 
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
         import.StarredPlaces.Count.ShouldBe(1);

--- a/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportDownloadHandlerTests.cs
+++ b/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportDownloadHandlerTests.cs
@@ -202,9 +202,11 @@ public class ImportDownloadHandlerTests
 
         var places = new List<StarredPlace>
         {
-            new("Name 1", "http://maps.google.com/?cid=111", "Addr 1", Alpha2Code.PL, 1.0, 2.0, DateTimeOffset.UtcNow, null),
-            new("Name 2", "http://maps.google.com/?cid=222", "Addr 2", Alpha2Code.PL, 3.0, 4.0, DateTimeOffset.UtcNow, null),
-            new("Name 3", "http://maps.google.com/?cid=333", "Addr 3", Alpha2Code.PL, 5.0, 6.0, DateTimeOffset.UtcNow, null)
+            new("Name 1", "http://maps.google.com/?cid=111", "Addr 1", Alpha2Code.PL, 1.0, 2.0, DateTimeOffset.UtcNow.AddDays(-1),
+                null),
+            new("Name 2", "http://maps.google.com/?cid=222", "Addr 2", Alpha2Code.PL, 3.0, 4.0, DateTimeOffset.UtcNow.AddDays(-1),
+                null),
+            new("Name 3", "http://maps.google.com/?cid=333", "Addr 3", Alpha2Code.PL, 5.0, 6.0, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
 
         downloaderMock.Setup(p => p.ProvideAsync(It.IsAny<IReadOnlyList<Uri>>(), It.IsAny<CancellationToken>()))

--- a/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportProcessingHandlerTests.cs
+++ b/tests/Pinventory.Pins.Application.UnitTests/Importing/ImportProcessingHandlerTests.cs
@@ -43,13 +43,14 @@ public class ImportProcessingHandlerTests
 
         var places = new[]
         {
-            new StarredPlace("SameName", "http://maps.google.com/?cid=222", "Addr 1", Alpha2Code.PL, 1, 2, DateTimeOffset.UtcNow,
+            new StarredPlace("SameName", "http://maps.google.com/?cid=222", "Addr 1", Alpha2Code.PL, 1, 2,
+                DateTimeOffset.UtcNow.AddDays(-1),
                 null), // conflict by name
-            new StarredPlace("NewName", "http://maps.google.com/?cid=333", "Addr 2", Alpha2Code.PL, 3, 4, DateTimeOffset.UtcNow,
+            new StarredPlace("NewName", "http://maps.google.com/?cid=333", "Addr 2", Alpha2Code.PL, 3, 4, DateTimeOffset.UtcNow.AddDays(-1),
                 null), // update by placeId
-            new StarredPlace("Created", "http://maps.google.com/?cid=444", "Addr 3", Alpha2Code.PL, 5, 6, DateTimeOffset.UtcNow,
+            new StarredPlace("Created", "http://maps.google.com/?cid=444", "Addr 3", Alpha2Code.PL, 5, 6, DateTimeOffset.UtcNow.AddDays(-1),
                 null), // create new
-            new StarredPlace("Removed", "http://maps.google.com/?cid=555", "Addr 4", Alpha2Code.PL, 7, 8, DateTimeOffset.UtcNow,
+            new StarredPlace("Removed", "http://maps.google.com/?cid=555", "Addr 4", Alpha2Code.PL, 7, 8, DateTimeOffset.UtcNow.AddDays(-1),
                 null) // failed
         };
 
@@ -110,24 +111,26 @@ public class ImportProcessingHandlerTests
         // existing pins: one for conflict by name, one to update by place id
         var address = new Address("Addr X", Alpha2Code.PL);
         var location = new Location(10, 20);
-        var conflictPin = new Pin(userId, "SameName", new GooglePlaceId("111"), address, location, DateTimeOffset.UtcNow);
-        var updatePin = new Pin(userId, "OldName", new GooglePlaceId("333"), address, location, DateTimeOffset.UtcNow);
+        var conflictPin = new Pin(userId, "SameName", new GooglePlaceId("111"), address, location, DateTimeOffset.UtcNow.AddDays(-1));
+        var updatePin = new Pin(userId, "OldName", new GooglePlaceId("333"), address, location, DateTimeOffset.UtcNow.AddDays(-1));
         await dbContext.Pins.AddRangeAsync(conflictPin, updatePin);
 
         var places = new[]
         {
-            new StarredPlace("SameName", "http://maps.google.com/?cid=222", "Addr 1", Alpha2Code.PL, 1, 2, DateTimeOffset.UtcNow,
+            new StarredPlace("SameName", "http://maps.google.com/?cid=222", "Addr 1", Alpha2Code.PL, 1, 2,
+                DateTimeOffset.UtcNow.AddDays(-1),
                 null), // conflict by name
-            new StarredPlace("NewName", "http://maps.google.com/?cid=333", "Addr 2", Alpha2Code.PL, 3, 4, DateTimeOffset.UtcNow,
+            new StarredPlace("NewName", "http://maps.google.com/?cid=333", "Addr 2", Alpha2Code.PL, 3, 4, DateTimeOffset.UtcNow.AddDays(-1),
                 null), // update by placeId
-            new StarredPlace("Created", "http://maps.google.com/?cid=444", "Addr 3", Alpha2Code.PL, 5, 6, DateTimeOffset.UtcNow,
+            new StarredPlace("Created", "http://maps.google.com/?cid=444", "Addr 3", Alpha2Code.PL, 5, 6, DateTimeOffset.UtcNow.AddDays(-1),
                 null) // create new
         };
 
         var registerResult = import.RegisterPlaces(places);
         // Add more places to ensure TryComplete will fail
         import.RegisterPlaces([
-            new StarredPlace("Extra", "http://maps.google.com/?cid=999", "Addr", Alpha2Code.PL, 9, 10, DateTimeOffset.UtcNow, null)
+            new StarredPlace("Extra", "http://maps.google.com/?cid=999", "Addr", Alpha2Code.PL, 9, 10, DateTimeOffset.UtcNow.AddDays(-1),
+                null)
         ]);
 
         await dbContext.Imports.AddAsync(import);
@@ -189,7 +192,8 @@ public class ImportProcessingHandlerTests
 
         var places = new[]
         {
-            new StarredPlace("Name", "http://maps.google.com/?cid=111", "Addr", Alpha2Code.PL, 1, 2, DateTimeOffset.UtcNow, null)
+            new StarredPlace("Name", "http://maps.google.com/?cid=111", "Addr", Alpha2Code.PL, 1, 2, DateTimeOffset.UtcNow.AddDays(-1),
+                null)
         };
 
         var registerResult = import.RegisterPlaces(places);

--- a/tests/Pinventory.Pins.Domain.UnitTests/ImportTests.cs
+++ b/tests/Pinventory.Pins.Domain.UnitTests/ImportTests.cs
@@ -145,8 +145,8 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
 
         // Act
@@ -166,12 +166,12 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var place1 = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         var place2 = new List<StarredPlace>
         {
-            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
 
         // Act
@@ -191,7 +191,7 @@ public class ImportTests
         var import = new Import("user123");
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
 
         // Act
@@ -261,8 +261,8 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         var registerResult = import.RegisterPlaces(starredPlaces);
         registerResult.IsSuccess.ShouldBeTrue();
@@ -294,12 +294,12 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var place1 = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         var place2 = new List<StarredPlace>
         {
-            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(place1);
         import.RegisterPlaces(place2);
@@ -330,7 +330,7 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
         var validatorMock = new Mock<IStarredPlaceValidator>();
@@ -375,8 +375,8 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
         var validatorMock = new Mock<IStarredPlaceValidator>();
@@ -474,8 +474,8 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
         import.StarredPlaces.Count.ShouldBe(2);
@@ -520,9 +520,9 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 3", "https://maps.google.com/3", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
 
@@ -551,8 +551,8 @@ public class ImportTests
         var import = await Imports.CreateStartedImport();
         var starredPlaces = new List<StarredPlace>
         {
-            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow, null),
-            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow, null)
+            new("Place 1", "https://maps.google.com/1", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null),
+            new("Place 2", "https://maps.google.com/2", null, null, null, null, DateTimeOffset.UtcNow.AddDays(-1), null)
         };
         import.RegisterPlaces(starredPlaces);
 
@@ -574,7 +574,7 @@ public class ImportTests
     public void Period_defaults_to_AllTime_when_not_provided()
     {
         // Arrange & Act
-        var before = DateTimeOffset.UtcNow;
+        var before = DateTimeOffset.UtcNow.AddDays(-2);
         var import = new Import("user123");
         var after = DateTimeOffset.UtcNow;
 

--- a/tests/Pinventory.Pins.Domain.UnitTests/PeriodTests.cs
+++ b/tests/Pinventory.Pins.Domain.UnitTests/PeriodTests.cs
@@ -1,0 +1,102 @@
+﻿using Shouldly;
+
+namespace Pinventory.Pins.Domain.UnitTests;
+
+public class PeriodTests
+{
+    private static readonly DateTimeOffset FixedEndDate = new(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public void create_clamps_start_to_unix_epoch_when_start_is_before_unix_epoch()
+    {
+        // Arrange
+        var startBeforeEpoch = DateTimeOffset.UnixEpoch.AddDays(-1);
+        var validEnd = FixedEndDate;
+
+        // Act
+        var result = Period.Create(startBeforeEpoch, validEnd);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Start.ShouldBe(DateTimeOffset.UnixEpoch);
+        result.Value.End.ShouldBe(validEnd);
+    }
+
+    [Test]
+    public void Create_clamps_start_to_unix_epoch_when_start_is_very_early()
+    {
+        // Arrange
+        var veryEarlyStart = DateTimeOffset.MinValue;
+        var validEnd = FixedEndDate;
+
+        // Act
+        var result = Period.Create(veryEarlyStart, validEnd);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Start.ShouldBe(DateTimeOffset.UnixEpoch);
+        result.Value.End.ShouldBe(validEnd);
+    }
+
+    [Test]
+    public void Create_returns_period_start_must_be_before_end_error_when_clamped_start_equals_end()
+    {
+        // Arrange
+        var startBeforeEpoch = DateTimeOffset.UnixEpoch.AddDays(-1);
+        var endAtEpoch = DateTimeOffset.UnixEpoch;
+
+        // Act
+        var result = Period.Create(startBeforeEpoch, endAtEpoch);
+
+        // Assert
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.ShouldContain(e => e is Errors.Period.IncorrectPeriodDates);
+    }
+
+    [Test]
+    public void create_returns_period_start_must_be_before_end_error_when_clamped_start_is_after_end()
+    {
+        // Arrange
+        var veryEarlyStart = DateTimeOffset.MinValue;
+        var endBeforeEpoch = DateTimeOffset.UnixEpoch.AddDays(-1);
+
+        // Act
+        var result = Period.Create(veryEarlyStart, endBeforeEpoch);
+
+        // Assert
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.ShouldContain(e => e is Errors.Period.IncorrectPeriodDates);
+    }
+
+    [Test]
+    public void create_returns_valid_period_when_start_is_exactly_unix_epoch()
+    {
+        // Arrange
+        var startAtEpoch = DateTimeOffset.UnixEpoch;
+        var validEnd = FixedEndDate;
+
+        // Act
+        var result = Period.Create(startAtEpoch, validEnd);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Start.ShouldBe(DateTimeOffset.UnixEpoch);
+        result.Value.End.ShouldBe(validEnd);
+    }
+
+    [Test]
+    public void create_returns_valid_period_when_start_is_after_unix_epoch()
+    {
+        // Arrange
+        var startAfterEpoch = DateTimeOffset.UnixEpoch.AddDays(1);
+        var validEnd = FixedEndDate;
+
+        // Act
+        var result = Period.Create(startAfterEpoch, validEnd);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Start.ShouldBe(startAfterEpoch);
+        result.Value.End.ShouldBe(validEnd);
+    }
+}

--- a/tests/Pinventory.Pins.Domain.UnitTests/PeriodTests.cs
+++ b/tests/Pinventory.Pins.Domain.UnitTests/PeriodTests.cs
@@ -7,7 +7,7 @@ public class PeriodTests
     private static readonly DateTimeOffset FixedEndDate = new(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
 
     [Test]
-    public void create_clamps_start_to_unix_epoch_when_start_is_before_unix_epoch()
+    public void Create_clamps_start_to_unix_epoch_when_start_is_before_unix_epoch()
     {
         // Arrange
         var startBeforeEpoch = DateTimeOffset.UnixEpoch.AddDays(-1);
@@ -54,7 +54,7 @@ public class PeriodTests
     }
 
     [Test]
-    public void create_returns_period_start_must_be_before_end_error_when_clamped_start_is_after_end()
+    public void Create_returns_period_start_must_be_before_end_error_when_clamped_start_is_after_end()
     {
         // Arrange
         var veryEarlyStart = DateTimeOffset.MinValue;
@@ -69,7 +69,7 @@ public class PeriodTests
     }
 
     [Test]
-    public void create_returns_valid_period_when_start_is_exactly_unix_epoch()
+    public void Create_returns_valid_period_when_start_is_exactly_unix_epoch()
     {
         // Arrange
         var startAtEpoch = DateTimeOffset.UnixEpoch;
@@ -85,7 +85,7 @@ public class PeriodTests
     }
 
     [Test]
-    public void create_returns_valid_period_when_start_is_after_unix_epoch()
+    public void Create_returns_valid_period_when_start_is_after_unix_epoch()
     {
         // Arrange
         var startAfterEpoch = DateTimeOffset.UnixEpoch.AddDays(1);

--- a/tests/Pinventory.Pins.Infrastructure.UnitTests/Services/ImportConcurrencyPolicyTests.cs
+++ b/tests/Pinventory.Pins.Infrastructure.UnitTests/Services/ImportConcurrencyPolicyTests.cs
@@ -41,7 +41,8 @@ public class ImportConcurrencyPolicyTests
         policyMock.Setup(p => p.CanStartImportAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         await completedImport.StartAsync("job-1", policyMock.Object);
         completedImport.RegisterPlaces([
-            new StarredPlace("Place", "http://maps.google.com/?cid=123", "Address", Alpha2Code.PL, 1.0, 2.0, DateTimeOffset.UtcNow, null)
+            new StarredPlace("Place", "http://maps.google.com/?cid=123", "Address", Alpha2Code.PL, 1.0, 2.0,
+                DateTimeOffset.UtcNow.AddDays(-1), null)
         ]);
 
         var placeId = completedImport.StarredPlaces.Single().Id;


### PR DESCRIPTION
This pull request introduces improvements to how imports are filtered and processed within a specified period, and ensures that the import logic consistently respects period boundaries. It also strengthens the validation of period creation and updates the import UI to start new imports from the last completed job. Additionally, all related unit tests have been updated to reflect the new logic for handling place dates within periods.

**Domain logic and validation improvements:**

* The `RegisterPlaces` method in `Import.cs` now only registers places whose `AddedDate` falls within the import's `Period`, ensuring imports are strictly period-bound.
* The `Period` record has been changed from `partial` to `sealed`, and its creation logic now clamps the start date to `UnixEpoch` if an earlier date is provided, preventing invalid periods. [[1]](diffhunk://#diff-be5efe65f61a86e3cff198e2e8daf3bb0671703d0ed85ddf4fafa92416548b8aL6-R6) [[2]](diffhunk://#diff-be5efe65f61a86e3cff198e2e8daf3bb0671703d0ed85ddf4fafa92416548b8aR24-R28)

**Import UI and workflow changes:**

* The import start process in `Import.razor` now initializes the period's start date from the most recent completed import, ensuring continuity and avoiding overlapping imports.

**Unit test updates for period filtering:**

* All unit tests involving `StarredPlace` creation now use `DateTimeOffset.UtcNow.AddDays(-1)` instead of `DateTimeOffset.UtcNow`, ensuring that test data falls within the default period and matches the new filtering logic. [[1]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L148-R149) [[2]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L169-R174) [[3]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L194-R194) [[4]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L264-R265) [[5]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L297-R302) [[6]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L333-R333) [[7]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L378-R379) [[8]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L477-R478) [[9]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L523-R525) [[10]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L554-R555) [[11]](diffhunk://#diff-8245b5b0a87ad77676459a4fb0b9d6f047dba0906befe95190927acb2d265a97L577-R577) [[12]](diffhunk://#diff-2810ca68af77d75780eca93d259230d71436d05a23d6fdaa75450f21a1d9da5dL164-R164) [[13]](diffhunk://#diff-af7a6db7edf0dcaf752fa2303deb0790a09b018851169b7fbd37cc3b56ebeb02L205-R209) [[14]](diffhunk://#diff-33ab3baf750c83e5b3e6e15a2853b5d9908d13c508d4170cdf633ce12e4af3c5L46-R53) [[15]](diffhunk://#diff-33ab3baf750c83e5b3e6e15a2853b5d9908d13c508d4170cdf633ce12e4af3c5L113-R133) [[16]](diffhunk://#diff-33ab3baf750c83e5b3e6e15a2853b5d9908d13c508d4170cdf633ce12e4af3c5L192-R196) [[17]](diffhunk://#diff-63fdd9071a6818356fa61090bf9e23d18f5e688f137b3f71107c7d47aece72c5L44-R45)

**Internal helper logic:**

* Introduced a local helper function `IsInPeriod` within `RegisterPlaces` to encapsulate the period check for each place, improving readability and maintainability.