### PR TITLE
Refactor domain infrastructure for aggregates and events

### DIFF
--- a/src/Pinventory.Pins.Domain/Abstractions/AggregateRoot.cs
+++ b/src/Pinventory.Pins.Domain/Abstractions/AggregateRoot.cs
@@ -14,4 +14,6 @@ public abstract class AggregateRoot(Guid? id) : Entity(id)
     public uint Version { get; protected set; }
 
     protected void Raise(DomainEvent @event) => _domainEvents.Add(@event);
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
 }

--- a/src/Pinventory.Pins.Domain/Places/Pin.cs
+++ b/src/Pinventory.Pins.Domain/Places/Pin.cs
@@ -1,4 +1,6 @@
-﻿using FluentResults;
+﻿using System.Collections.Immutable;
+
+using FluentResults;
 
 using Pinventory.Pins.Domain.Abstractions;
 using Pinventory.Pins.Domain.Importing;
@@ -26,7 +28,7 @@ public sealed class Pin(
     public PinStatus Status { get; private set; } = status;
     public DateTimeOffset StatusUpdatedAt { get; private set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset AddedAt { get; private set; } = addedAt;
-    public IReadOnlyCollection<Tag> Tags => _tags;
+    public IReadOnlyCollection<Tag> Tags => _tags.ToImmutableHashSet();
 
     public static Pin Create(string ownerId, GooglePlaceId placeId, StarredPlace place)
     {

--- a/src/Pinventory.Pins.Domain/Tags/TagCatalog.cs
+++ b/src/Pinventory.Pins.Domain/Tags/TagCatalog.cs
@@ -1,4 +1,6 @@
-﻿using FluentResults;
+﻿using System.Collections.Immutable;
+
+using FluentResults;
 
 using Pinventory.Pins.Domain.Abstractions;
 
@@ -13,7 +15,7 @@ public sealed class TagCatalog(
     private readonly HashSet<Tag> _tags = [];
 
     public string? OwnerId { get; private set; } = ownerId;
-    public IReadOnlyCollection<Tag> Tags => _tags;
+    public IReadOnlyCollection<Tag> Tags => _tags.ToImmutableHashSet();
 
     public Result<IEnumerable<Tag>> DefineTags(IEnumerable<string> tags)
     {

--- a/src/Pinventory.Pins.Infrastructure/Middlewares/DomainEventsPublisherMiddleware.cs
+++ b/src/Pinventory.Pins.Infrastructure/Middlewares/DomainEventsPublisherMiddleware.cs
@@ -8,12 +8,20 @@ public class DomainEventsPublisherMiddleware
 {
     public async Task PostProcessAsync(PinsDbContext dbContext, IMessageBus bus)
     {
-        foreach (var @event in dbContext.ChangeTracker
-                     .Entries<AggregateRoot>()
-                     .SelectMany(x => x.Entity.DomainEvents)
-                     .ToList())
+        var aggregates = dbContext.ChangeTracker
+            .Entries<AggregateRoot>()
+            .Select(x => x.Entity)
+            .Where(x => x.DomainEvents.Count > 0)
+            .ToList();
+
+        foreach (var @event in aggregates.SelectMany(x => x.DomainEvents).ToList())
         {
             await bus.PublishAsync(@event);
+        }
+
+        foreach (var aggregate in aggregates)
+        {
+            aggregate.ClearDomainEvents();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to how domain events are managed and exposes collections in a more robust and immutable way. The most significant changes include adding a method to clear domain events from aggregates, updating how tags are exposed in domain entities, and ensuring domain events are cleared after publishing. These updates improve the consistency and reliability of the domain model and event publishing process.

**Domain Events Management:**

* Added a `ClearDomainEvents` method to the `AggregateRoot` base class, allowing domain events to be cleared from aggregates after they have been published.
* Updated the `DomainEventsPublisherMiddleware` to collect aggregates with pending domain events, publish all events, and then clear the events from each aggregate to prevent duplicate processing.

**Immutable Collections:**

* Changed the `Tags` property in both `Pin` and `TagCatalog` domain entities to return an immutable hash set, improving safety and preventing unintended modifications from outside the class. [[1]](diffhunk://#diff-927f423339b883ad2e669fb40d1d32a8a4e28983c19b2410d9c0777ac1cf4ee1L29-R31) [[2]](diffhunk://#diff-9f445a168d8aebe1f8974982e0cb1dcaca859210b2099c923de5b38e29ee75d5L16-R18)
* Added `System.Collections.Immutable` imports in relevant files to support the use of immutable collections. [[1]](diffhunk://#diff-927f423339b883ad2e669fb40d1d32a8a4e28983c19b2410d9c0777ac1cf4ee1L1-R3) [[2]](diffhunk://#diff-9f445a168d8aebe1f8974982e0cb1dcaca859210b2099c923de5b38e29ee75d5L1-R3)